### PR TITLE
Разрешить подсветку bemjson как js

### DIFF
--- a/lib/plugins/inline-bemjson.js
+++ b/lib/plugins/inline-bemjson.js
@@ -29,9 +29,9 @@ module.exports = function (helper) {
          *     text: 'Click me!'
          * })
          * ```
-         * 
+         *
          * или
-         * 
+         *
          * ```js
          * ({
          *     block: 'button',


### PR DESCRIPTION
Сейчас в документации bem-components bemjson-примеры не имеют подсветки синтаксиса из-за не поддержки на GitHub.
Предлагаю оформлять bemjson-примеры в markdown с тегом js, а не bemjson.

Также это касается и bem.info.
